### PR TITLE
15 cl add debug toggle

### DIFF
--- a/v1.1.1/js/Node.js
+++ b/v1.1.1/js/Node.js
@@ -12,11 +12,11 @@ Node.COLORS = {
 	4: "#7FD4FF", // blue
 	5: "#A97FFF" // purple
 };
-
 Node.defaultValue = 0.5;
 Node.defaultHue = 0;
 Node.defaultExplodes = false;
 Node.explodedColor = "#808080";
+Node.displayDebugText = false;
 
 Node.DEFAULT_RADIUS = 60;
 
@@ -39,7 +39,8 @@ function Node(model, config){
 		label: "?",
 		explodes: Node.defaultExplodes,
 		hue: Node.defaultHue,
-		radius: Node.DEFAULT_RADIUS
+		radius: Node.DEFAULT_RADIUS,
+		displayDebug: Node.displayDebugText 
 	});
 
 	// Value: from 0 to 1
@@ -112,6 +113,11 @@ function Node(model, config){
 	var _listenerReset = subscribe("model/reset", function(){
 		self.value = self.init;
 		self.exploded = false;
+	});
+	var _listenerDebugToggle = subscribe("debug/toggle", function(){
+		self.displayDebug = !self.displayDebug;
+		self.draw(self.model.context);
+		publish("mousemove")	// To force a page redraw, otherwise text will still be visible behind nodes
 	});
 
 	//////////////////////////////////////
@@ -280,12 +286,13 @@ function Node(model, config){
 	
 		var roundedValue = Math.round(self.value * 100) / 100; // Temp variable solely to cleanly display value
 		
-		// resize value text
-		self.fillSelfSizingText(ctx, r, roundedValue, 40); // Display value slightly below label.
+		if(self.displayDebug) {
+			// resize value text
+			self.fillSelfSizingText(ctx, r, roundedValue, 40); // Display value slightly below label.
 
-
-		// resize explody test
-		self.fillSelfSizingText(ctx, r, "" + self.explodes + ", " + self.exploded, 80);
+			// resize explody text
+			self.fillSelfSizingText(ctx, r, "" + self.explodes + ", " + self.exploded, 80);
+		}
 
 		// WOBBLE CONTROLS
 		var cl = 40;
@@ -343,6 +350,7 @@ function Node(model, config){
 		unsubscribe("mousedown",_listenerMouseDown);
 		unsubscribe("mouseup",_listenerMouseUp);
 		unsubscribe("model/reset",_listenerReset);
+		unsubscribe("debug/toggle",_listenerDebugToggle);
 
 		// Remove from parent!
 		model.removeNode(self);

--- a/v1.1.1/js/Sidebar.js
+++ b/v1.1.1/js/Sidebar.js
@@ -182,6 +182,7 @@ function Sidebar(loopy){
 
 			"<hr/><br>"+
 
+			"<span class='mini_button' onclick='publish(\"debug/toggle\")'>toggle debug values</span> <br><br>"+
 			"<span class='mini_button' onclick='publish(\"modal\",[\"save_link\"])'>save as link</span> <br><br>"+
 			"<span class='mini_button' onclick='publish(\"export/file\")'>save as file</span> "+
 			"<span class='mini_button' onclick='publish(\"import/file\")'>load from file</span> <br><br>"+

--- a/v1.1.1/js/Sidebar.js
+++ b/v1.1.1/js/Sidebar.js
@@ -174,7 +174,7 @@ function Sidebar(loopy){
 		page.addComponent(new ComponentHTML({
 			html: ""+
 			
-			"<b style='font-size:1.4em'>LOOPY</b> (v2.0)<br>a tool for thinking in systems<br><br>"+
+			"<b style='font-size:1.4em'>LOOPY</b> (v1.1.1)<br>a tool for thinking in systems<br><br>"+
 
 			"<span class='mini_button' onclick='publish(\"modal\",[\"examples\"])'>see examples</span> "+
 			"<span class='mini_button' onclick='publish(\"modal\",[\"howto\"])'>how to</span> "+


### PR DESCRIPTION
Still haven't made a PR template, sorry

## What does this PR accomplish?
Resolves #15 

## How does it do it?
Made use of the pub/sub pattern. Added a line in `Sidebar.js` to insert a new button on the "Edit" sidebar, and gave it an onclick event of publishing `"debug/toggle"`. Added a `self.displayDebug` field to `Node.js`, and added line subscribing the node instance to the `"debug/toggle"` topic, whereupon it inverts the value of `displayDebug`, redraws the node, and then refreshes the background.

## Tada
![image](https://user-images.githubusercontent.com/44409145/142682510-c6f29cec-e0db-493b-8a0c-b5687c629f87.png)
![image](https://user-images.githubusercontent.com/44409145/142682565-aecd8e60-a6c2-4ae2-9d93-2df7bf3a8ef7.png)

## Be good
- [x] I've tested this feature as rigorously as I can
- [x] I've confirmed no new bugs being introduced from my work