### PR TITLE
Fix keyboard shortcuts by removing prevent default and stop propogation

### DIFF
--- a/v1.1.1/js/Key.js
+++ b/v1.1.1/js/Key.js
@@ -32,15 +32,11 @@
 		var code = KEY_CODES[event.keyCode];
 	    Key[code] = true;
 	    publish("key/"+code);
-	    event.stopPropagation();
-	    event.preventDefault();
 	}
 	Key.onKeyUp = function(event){
 		if(window.loopy && loopy.modal && loopy.modal.isShowing) return;
 		var code = KEY_CODES[event.keyCode];
 	    Key[code] = false;
-	    event.stopPropagation();
-	    event.preventDefault();
 	}
 	window.addEventListener("keydown",Key.onKeyDown,false);
 	window.addEventListener("keyup",Key.onKeyUp,false);


### PR DESCRIPTION
Resolves #37 by removing the prevent default/stop propagation calls on events inside the Key.js handler.