### PR TITLE
Graph canvas resize issue

### DIFF
--- a/v1.1.1/js/NodeGraph.js
+++ b/v1.1.1/js/NodeGraph.js
@@ -9,7 +9,7 @@ function NodeGraph(model) {
     self.loopy = model.loopy;
     self.model = model;
 
-    var canvas = _createCanvas('NodeGraph', 1600, 1400, 'graph_canvas');
+    var canvas = _createCanvas('NodeGraph', 400, 350, 'graph_canvas');
     const ctx = canvas.getContext('2d');
 
     // Get information from nodes


### PR DESCRIPTION
Work on resolving the issue with the canvas resizing on window resize. This happens due to NodeGraph.js using helpers.js createCanvas which registers a resize handler. This resize handler sets css width/height to half of the canvas width and height. 

Options I can think of:
1. Disable resizing for graph canvas. By creating a canvas in the html instead of dynamically or just not registering the resize handler. Fixes the immediate issue but might cause new issues when trying to work at different screen sizes.
2. Use a custom resize handler/add a parameter to the existing resize handler to disable the 2:1 scaling between css and canvas.