### PR TITLE
Remove rendering of button to toggle debug values and fixed flicker bug

### DIFF
--- a/v1.1.1/js/Node.js
+++ b/v1.1.1/js/Node.js
@@ -123,7 +123,6 @@ function Node(model, config){
 	});
 	var _listenerDebugToggle = subscribe("debug/toggle", function(){
 		self.displayDebug = !self.displayDebug;
-		self.draw(self.model.context);
 		publish("mousemove")	// To force a page redraw, otherwise text will still be visible behind nodes
 	});
 

--- a/v1.1.1/js/Sidebar.js
+++ b/v1.1.1/js/Sidebar.js
@@ -207,7 +207,7 @@ function Sidebar(loopy){
 
 			"<hr/><br>"+
 
-			"<span class='mini_button' onclick='publish(\"debug/toggle\")'>toggle debug values</span> <br><br>"+
+			// "<span class='mini_button' onclick='publish(\"debug/toggle\")'>toggle debug values</span> <br><br>"+
 			"<span class='mini_button' onclick='publish(\"model/resetZoom\")'>reset zoom</span> <br><br>"+
 			"<span class='mini_button' onclick='publish(\"graph/toggleVisible\")'>toggle Graph visibility</span> <br><br>"+
 			"<span class='mini_button' onclick='publish(\"modal\",[\"save_link\"])'>save as link</span> <br><br>"+


### PR DESCRIPTION
Resolves #57.

No longer renders the debug toggle in the sidebar. Additionally, I went ahead and fixed the bug causing a node to flicker back into existence after it has been deleted when toggling debug values.