### PR TITLE
Fix template ghosting due to no redraw on tool change

### DIFF
--- a/v1.1.1/js/Template.js
+++ b/v1.1.1/js/Template.js
@@ -184,5 +184,8 @@ function Template(model, prototype) {
 
 		// Killed!
 		publish("kill", [self]);
+		
+		// Force redraw
+		publish("mousemove");
 	};
 }

--- a/v1.1.1/js/Toolbar.js
+++ b/v1.1.1/js/Toolbar.js
@@ -57,6 +57,8 @@ function Toolbar(loopy){
 	// Set Tool
 	self.currentTool = "ink";
 	self.setTool = function(tool){
+		// Remove previous template tool if assigned
+		if(loopy.model.activeTemplate) loopy.model.activeTemplate.kill();
 		self.currentTool = tool;
 		var name = "TOOL_"+tool.toUpperCase();
 		loopy.tool = Loopy[name];


### PR DESCRIPTION
Resolves #49.

Disables the active template whenever switching tools and force a redraw when the template is disabled in order to fix template remaining despite switching tools after holding mouse still for the draw cooldown.