### PR TITLE
58 alternative mouse fix

### DIFF
--- a/v1.1.1/index.html
+++ b/v1.1.1/index.html
@@ -38,7 +38,7 @@
 
 	<!-- Loopy & Ink -->
 	<div id="canvasses"></div>
-	<div id="graph_div"></div>
+	<div id="graph_div" style="top: 10px; left: 100px;"></div>
 
 	<!-- The Tools' UI -->
 	<div id="toolbar"></div>

--- a/v1.1.1/js/Ink.js
+++ b/v1.1.1/js/Ink.js
@@ -27,8 +27,8 @@ function Ink(loopy){
 
 	// Drawing!
 	self.drawInk = function(){
-		//Don't draw if the mouse isn't pressed or if the user is dragging over the graph
-		if(!Mouse.pressed || self.loopy.model.graph.isBeingDragged(Mouse.x, Mouse.y)) return;
+		//Don't draw if the mouse isn't pressed
+		if(!Mouse.pressed) return;
 
 		// Last point
 		var lastPoint = self.strokeData[self.strokeData.length-1];

--- a/v1.1.1/js/Loopy.js
+++ b/v1.1.1/js/Loopy.js
@@ -35,7 +35,6 @@ function Loopy(config){
 
 	// Mouse
 	Mouse.init(document.getElementById("canvasses")); // TODO: ugly fix, ew
-	Mouse.init(document.getElementById("graph_div"));
 
 	// Model
 	self.model = new Model(self);

--- a/v1.1.1/js/Model.js
+++ b/v1.1.1/js/Model.js
@@ -503,13 +503,6 @@ function Model(loopy){
 		return null;
 	};
 
-	self.getGraphByPoint = function(x,y) {
-		if(self.graph.isPointOnGraph(x, y)) {
-			return self.graph;
-		} 
-		return null;
-	}
-
 	// Click to edit!
 	subscribe("mouseclick",function(){
 
@@ -531,11 +524,6 @@ function Model(loopy){
 			return;
 		}
 
-		var clickedGraph = self.getGraphByPoint(Mouse.x, Mouse.y);
-		if(clickedGraph) {
-			loopy.sidebar.edit(clickedGraph);
-			return;
-		}
 		// Did you click on an edge label? If so, edit THAT edge.
 		var clickedEdge = self.getEdgeByPoint(Mouse.x, Mouse.y);
 		if(clickedEdge){

--- a/v1.1.1/js/NodeGraph.js
+++ b/v1.1.1/js/NodeGraph.js
@@ -20,6 +20,7 @@ function NodeGraph(model) {
     self.isHidden = false;
     self.parent = 'graph_div';
 
+    var parentEle = document.getElementById(self.parent);
     var canvas = _createCanvas('NodeGraph', self.graphW, self.graphH, self.parent);
     const ctx = canvas.getContext('2d');
 
@@ -29,7 +30,34 @@ function NodeGraph(model) {
     backgroundColors = []
     labels = []
     nodeData = []
-    
+
+    registerGraphClicks(document.getElementById(self.parent));
+    function registerGraphClicks(parentElement) {
+        let startedOnTarget = false;
+        let moved = false;
+
+        let mousedownhandler = function(e) {
+            startedOnTarget = true;
+            moved = false;
+        }
+
+        let mousemovehandler = function() {
+            moved = true;
+        }
+
+        let mouseuphandler = function(e) {
+            if(startedOnTarget && !moved) {
+                self.loopy.sidebar.edit(self);
+            }
+
+            startedOnTarget = false;
+            moved = false;
+        };
+
+        parentElement.addEventListener("mousedown", mousedownhandler);
+        parentElement.addEventListener("mousemove", mousemovehandler);
+        parentElement.addEventListener("mouseup", mouseuphandler);
+    }
    
     self.chart = new Chart(ctx, {
         type: 'line',
@@ -151,22 +179,11 @@ function NodeGraph(model) {
         self.chart.resize(NodeGraph.defaultWidth, NodeGraph.defaultHeight);
     });
 
-    var _listenerMouseUp = subscribe("mouseup", function() {
-        self.isDragging = false;
-    });
-
     self.isPointOnGraph = function(x, y) {
         if(self.isHidden) {
             return false;
         }
         return _isPointInBox(x, y, self.getBounds());
-    }
-
-    self.isBeingDragged = function(x,y) {
-        if(Mouse.pressed  && self.isPointOnGraph(x,y)) {
-            self.isDragging = true;
-        }
-        return self.isDragging;
     }
 
     self.getBounds = function() {

--- a/v1.1.1/js/NodeGraph.js
+++ b/v1.1.1/js/NodeGraph.js
@@ -37,15 +37,18 @@ function NodeGraph(model) {
         let moved = false;
 
         let mousedownhandler = function(e) {
+            if(e.button == Mouse.RIGHT) return;
             startedOnTarget = true;
             moved = false;
         }
 
-        let mousemovehandler = function() {
+        let mousemovehandler = function(e) {
+            if(e.button == Mouse.RIGHT) return;
             moved = true;
         }
 
         let mouseuphandler = function(e) {
+            if(e.button == Mouse.RIGHT) return;
             if(startedOnTarget && !moved) {
                 self.loopy.sidebar.edit(self);
             }
@@ -169,8 +172,8 @@ function NodeGraph(model) {
         else
         {
             self.chart.resize(NodeGraph.defaultWidth, NodeGraph.defaultHeight);
-            containingDiv.style.width = 400;    // Hardcoded because I'm lazy
-            containingDiv.style.height = 350;
+            containingDiv.style.width = NodeGraph.defaultWidth;
+            containingDiv.style.height = NodeGraph.defaultHeight;
             self.isHidden = false;
         }
     });
@@ -188,8 +191,8 @@ function NodeGraph(model) {
 
     self.getBounds = function() {
         return {
-            x: canvas.style.left,
-            y: canvas.style.top,
+            x: parseInt(containingDiv.style.left, 10),
+            y: parseInt(containingDiv.style.top, 10),
             width: self.graphW,
             height: self.graphH
         };


### PR DESCRIPTION
Resolves #58

An alternative fix to #63 that aims to remove the Mouse.init from graph canvas and instead use its own click handling. I also incorporated a few of the QoL changes from #63 such as removing the hardcoded values in NodeGraph.